### PR TITLE
fixed build on ubuntu 17.10

### DIFF
--- a/src/lua_files.cc
+++ b/src/lua_files.cc
@@ -30,8 +30,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <string>
 #include <algorithm>
+#include <vector>
 #include <sys/stat.h>
 #include <dirent.h>
 


### PR DESCRIPTION
Missing include  of std::vector std::string failed to build on ubuntu 17.10